### PR TITLE
Remove email API debug logs

### DIFF
--- a/src/app/api/send-email/route.ts
+++ b/src/app/api/send-email/route.ts
@@ -2,10 +2,6 @@ import { NextRequest, NextResponse } from 'next/server';
 import nodemailer from 'nodemailer';
 
 export async function POST(req: NextRequest) {
-  // Debug: Print environment variables
-  console.log('GMAIL_USER:', process.env.GMAIL_USER);
-  console.log('GMAIL_APP_PASS:', process.env.GMAIL_APP_PASS ? '***' : undefined);
-  console.log('RECEIVER:', process.env.RECEIVER);
   try {
     const body = await req.json();
     const { name, email, message, formType, ...rest } = body;


### PR DESCRIPTION
## Summary
- clean up the `send-email` API route by deleting console logs of sensitive env vars

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ee5875f08327b14e4349ba47873c