### PR TITLE
Optimize home page components

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,14 @@
 import Navbar from '@/components/layout/Navbar'
 import Hero from '@/components/home/Hero'
-import WhyChooseUs from '@/components/home/WhyChooseUs'
-import Testimonials from '@/components/home/Testimonials'
+import dynamic from 'next/dynamic'
+
+const WhyChooseUs = dynamic(() => import('@/components/home/WhyChooseUs'), {
+  loading: () => <p className="p-4 text-center">Loading...</p>,
+})
+const Testimonials = dynamic(
+  () => import('@/components/home/Testimonials'),
+  { loading: () => <p className="p-4 text-center">Loading...</p> }
+)
 
 export default function Home() {
   return (

--- a/src/components/home/Testimonials.tsx
+++ b/src/components/home/Testimonials.tsx
@@ -37,7 +37,9 @@ const testimonials = [
   },
 ]
 
-export default function Testimonials() {
+import { memo } from 'react'
+
+function Testimonials() {
   return (
     <section className="py-16 bg-green-50">
       <div className="w-full px-4">
@@ -59,4 +61,6 @@ export default function Testimonials() {
       </div>
     </section>
   )
-} 
+}
+
+export default memo(Testimonials)

--- a/src/components/home/WhyChooseUs.tsx
+++ b/src/components/home/WhyChooseUs.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react'
 import { CheckCircleIcon, GlobeAltIcon, UserGroupIcon, ShieldCheckIcon } from '@heroicons/react/24/outline'
 
 const features = [
@@ -23,7 +24,7 @@ const features = [
   },
 ]
 
-export default function WhyChooseUs() {
+function WhyChooseUs() {
   return (
     <section className="py-10 bg-white">
       <div className="w-full px-4 text-center">
@@ -40,4 +41,7 @@ export default function WhyChooseUs() {
       </div>
     </section>
   )
-} 
+}
+
+export default memo(WhyChooseUs)
+


### PR DESCRIPTION
## Summary
- lazy load heavy home page sections using `next/dynamic`
- memoize `WhyChooseUs` and `Testimonials` to avoid re-renders

## Testing
- `npx next lint` *(fails: Need to install next)*

------
https://chatgpt.com/codex/tasks/task_e_6847f263b37c83278d78ef2d635ed0ed